### PR TITLE
Add asset tools and blueprints commands

### DIFF
--- a/MCP/Commands/commands_asset_tools.py
+++ b/MCP/Commands/commands_asset_tools.py
@@ -1,0 +1,83 @@
+"""Asset tools-related commands for Unreal Engine.
+
+This module contains all asset tools-related commands for the UnrealMCP bridge,
+including creation, modification, and querying of assets.
+"""
+
+import sys
+import os
+from mcp.server.fastmcp import Context
+
+# Import send_command from the parent module
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from unreal_mcp_bridge import send_command
+
+def register_all(mcp):
+    """Register all asset tools-related commands with the MCP server."""
+    
+    @mcp.tool()
+    def create_asset(ctx: Context, package_path: str, name: str, asset_type: str, properties: dict = None) -> str:
+        """Create a new asset in the Unreal project.
+        
+        Args:
+            package_path: The path where the asset should be created (e.g., '/Game/Assets')
+            name: The name of the asset
+            asset_type: The type of asset to create (e.g., 'StaticMesh', 'Texture', etc.)
+            properties: Optional dictionary of asset properties to set.
+        """
+        try:
+            params = {
+                "package_path": package_path,
+                "name": name,
+                "asset_type": asset_type
+            }
+            if properties:
+                params["properties"] = properties
+            response = send_command("create_asset", params)
+            if response["status"] == "success":
+                return f"Created asset: {response['result']['name']} at path: {response['result']['path']}"
+            else:
+                return f"Error: {response['message']}"
+        except Exception as e:
+            return f"Error creating asset: {str(e)}"
+
+    @mcp.tool()
+    def modify_asset(ctx: Context, path: str, properties: dict) -> str:
+        """Modify an existing asset's properties.
+        
+        Args:
+            path: The full path to the asset (e.g., '/Game/Assets/MyAsset')
+            properties: Dictionary of asset properties to set.
+        """
+        try:
+            params = {
+                "path": path,
+                "properties": properties
+            }
+            response = send_command("modify_asset", params)
+            if response["status"] == "success":
+                return f"Modified asset: {response['result']['name']} at path: {response['result']['path']}"
+            else:
+                return f"Error: {response['message']}"
+        except Exception as e:
+            return f"Error modifying asset: {str(e)}"
+
+    @mcp.tool()
+    def get_asset_info(ctx: Context, path: str) -> dict:
+        """Get information about an asset.
+        
+        Args:
+            path: The full path to the asset (e.g., '/Game/Assets/MyAsset')
+            
+        Returns:
+            Dictionary containing asset information.
+        """
+        try:
+            params = {"path": path}
+            response = send_command("get_asset_info", params)
+            if response["status"] == "success":
+                return response["result"]
+            else:
+                return {"error": response["message"]}
+        except Exception as e:
+            return {"error": str(e)}

--- a/MCP/Commands/commands_blueprints.py
+++ b/MCP/Commands/commands_blueprints.py
@@ -1,0 +1,83 @@
+"""Blueprint-related commands for Unreal Engine.
+
+This module contains all blueprint-related commands for the UnrealMCP bridge,
+including creation, modification, and querying of blueprints.
+"""
+
+import sys
+import os
+from mcp.server.fastmcp import Context
+
+# Import send_command from the parent module
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from unreal_mcp_bridge import send_command
+
+def register_all(mcp):
+    """Register all blueprint-related commands with the MCP server."""
+    
+    @mcp.tool()
+    def create_blueprint(ctx: Context, package_path: str, name: str, parent_class: str = "Actor", properties: dict = None) -> str:
+        """Create a new blueprint in the Unreal project.
+        
+        Args:
+            package_path: The path where the blueprint should be created (e.g., '/Game/Blueprints')
+            name: The name of the blueprint
+            parent_class: The parent class of the blueprint (default: 'Actor')
+            properties: Optional dictionary of blueprint properties to set.
+        """
+        try:
+            params = {
+                "package_path": package_path,
+                "name": name,
+                "parent_class": parent_class
+            }
+            if properties:
+                params["properties"] = properties
+            response = send_command("create_blueprint", params)
+            if response["status"] == "success":
+                return f"Created blueprint: {response['result']['name']} at path: {response['result']['path']}"
+            else:
+                return f"Error: {response['message']}"
+        except Exception as e:
+            return f"Error creating blueprint: {str(e)}"
+
+    @mcp.tool()
+    def modify_blueprint(ctx: Context, blueprint_path: str, properties: dict) -> str:
+        """Modify an existing blueprint's properties.
+        
+        Args:
+            blueprint_path: The full path to the blueprint (e.g., '/Game/Blueprints/MyBlueprint')
+            properties: Dictionary of blueprint properties to set.
+        """
+        try:
+            params = {
+                "blueprint_path": blueprint_path,
+                "properties": properties
+            }
+            response = send_command("modify_blueprint", params)
+            if response["status"] == "success":
+                return f"Modified blueprint: {response['result']['name']} at path: {response['result']['path']}"
+            else:
+                return f"Error: {response['message']}"
+        except Exception as e:
+            return f"Error modifying blueprint: {str(e)}"
+
+    @mcp.tool()
+    def get_blueprint_info(ctx: Context, blueprint_path: str) -> dict:
+        """Get information about a blueprint.
+        
+        Args:
+            blueprint_path: The full path to the blueprint (e.g., '/Game/Blueprints/MyBlueprint')
+            
+        Returns:
+            Dictionary containing blueprint information.
+        """
+        try:
+            params = {"blueprint_path": blueprint_path}
+            response = send_command("get_blueprint_info", params)
+            if response["status"] == "success":
+                return response["result"]
+            else:
+                return {"error": response["message"]}
+        except Exception as e:
+            return {"error": str(e)}

--- a/MCP/unreal_mcp_bridge.py
+++ b/MCP/unreal_mcp_bridge.py
@@ -213,12 +213,17 @@ def load_user_tools():
             except Exception as e:
                 print(f"Error loading user tool {filename}: {str(e)}", file=sys.stderr)
 
+import Commands.commands_asset_tools as commands_asset_tools
+import Commands.commands_blueprints as commands_blueprints
+
 def main():
     """Main entry point for the Unreal MCP bridge."""
     print("Starting Unreal MCP bridge...", file=sys.stderr)
     try:
         load_commands()  # Load built-in commands
         load_user_tools()  # Load user-defined tools
+        commands_asset_tools.register_all(mcp)
+        commands_blueprints.register_all(mcp)
         mcp.run()  # Start the MCP bridge
     except Exception as e:
         print(f"Error starting MCP bridge: {str(e)}", file=sys.stderr)


### PR DESCRIPTION
Add new commands for asset tools and blueprints to the UnrealMCP bridge.

* **Asset Tools Commands:**
  - Add `MCP/Commands/commands_asset_tools.py` to define new commands for asset tools.
  - Import `send_command` from `unreal_mcp_bridge`.
  - Register commands using `register_all` function.
  - Implement commands: `create_asset`, `modify_asset`, and `get_asset_info`.

* **Blueprints Commands:**
  - Add `MCP/Commands/commands_blueprints.py` to define new commands for blueprints.
  - Import `send_command` from `unreal_mcp_bridge`.
  - Register commands using `register_all` function.
  - Implement commands: `create_blueprint`, `modify_blueprint`, and `get_blueprint_info`.

* **Bridge Integration:**
  - Modify `MCP/unreal_mcp_bridge.py` to import `commands_asset_tools` and `commands_blueprints` modules.
  - Call `register_all` function from both modules in the `main` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/luminati/UnrealMCP/pull/1?shareId=84886b08-8422-4070-98b1-d7458517875c).